### PR TITLE
✨[FEAT] #3 유저 정보 조회 API 구현

### DIFF
--- a/DriveMate/spring/src/main/java/DriveMate/spring/domain/member/controller/MemberRestContoller.java
+++ b/DriveMate/spring/src/main/java/DriveMate/spring/domain/member/controller/MemberRestContoller.java
@@ -8,13 +8,10 @@ import DriveMate.spring.domain.member.service.MemberService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/member")
+@RequestMapping("/members")
 @RequiredArgsConstructor
 public class MemberRestContoller {
 
@@ -35,6 +32,15 @@ public class MemberRestContoller {
             @RequestBody @Valid MemberRequestDto.userInfoDto request
     ) {
         MemberResponseDto.userInfodto response = memberService.userInfo(request);
+        return ApiResponse.onSuccess(SuccessStatus._OK, response);
+    }
+
+    // 개인정보 조회
+    @GetMapping("/info/{memberId}")
+    public ResponseEntity<ApiResponse> getUserinfo(
+            @PathVariable Long memberId
+    ) {
+        MemberResponseDto.userInfodto response = memberService.getUserInfo(memberId);
         return ApiResponse.onSuccess(SuccessStatus._OK, response);
     }
 

--- a/DriveMate/spring/src/main/java/DriveMate/spring/domain/member/service/MemberService.java
+++ b/DriveMate/spring/src/main/java/DriveMate/spring/domain/member/service/MemberService.java
@@ -7,4 +7,5 @@ import jakarta.validation.Valid;
 public interface MemberService {
     MemberResponseDto.signupResultdto signupMember(MemberRequestDto.signupDto request);
     MemberResponseDto.userInfodto userInfo(MemberRequestDto.userInfoDto request);
+    MemberResponseDto.userInfodto getUserInfo(Long memberId);
 }

--- a/DriveMate/spring/src/main/java/DriveMate/spring/domain/member/service/MemberServiceImpl.java
+++ b/DriveMate/spring/src/main/java/DriveMate/spring/domain/member/service/MemberServiceImpl.java
@@ -59,4 +59,18 @@ public class MemberServiceImpl implements MemberService {
                 .build();
 
     }
+
+    @Override
+    public MemberResponseDto.userInfodto getUserInfo(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
+
+        return MemberResponseDto.userInfodto.builder()
+                .memberId(member.getMemberId())
+                .name(member.getName())
+                .age(member.getAge())
+                .sex(member.getSex())
+                .occupation(member.getOccupation())
+                .build();
+    }
 }


### PR DESCRIPTION
## 📝 작업 내용
- memberId 값의 사용자의 개인 정보를 불러오는 API 구현하였습니다.

### 📸 스크린샷 (선택)
- 정상 응답
<img width="558" alt="image" src="https://github.com/user-attachments/assets/f802f5e1-17d9-495f-a89e-ca7ca2455051" />

- 해당 ID의 사용자가 없을 때
<img width="564" alt="image" src="https://github.com/user-attachments/assets/441fcf84-9b3a-4043-adb8-a013ac07d02a" />


