### PR TITLE
✨[FEAT] #6 대화 내역 저장 API 

### DIFF
--- a/DriveMate/spring/src/main/java/DriveMate/spring/domain/chat/controller/ChatRestController.java
+++ b/DriveMate/spring/src/main/java/DriveMate/spring/domain/chat/controller/ChatRestController.java
@@ -1,0 +1,11 @@
+package DriveMate.spring.domain.chat.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/chats")
+@RequiredArgsConstructor
+public class ChatRestController {
+}

--- a/DriveMate/spring/src/main/java/DriveMate/spring/domain/chat/controller/ChatRestController.java
+++ b/DriveMate/spring/src/main/java/DriveMate/spring/domain/chat/controller/ChatRestController.java
@@ -1,6 +1,15 @@
 package DriveMate.spring.domain.chat.controller;
 
+import DriveMate.spring.common.response.ApiResponse;
+import DriveMate.spring.common.status.SuccessStatus;
+import DriveMate.spring.domain.chat.dto.ChatRequestDto;
+import DriveMate.spring.domain.chat.dto.ChatResponseDto;
+import DriveMate.spring.domain.chat.service.ChatService;
+import DriveMate.spring.domain.member.dto.MemberResponseDto;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -8,4 +17,13 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/chats")
 @RequiredArgsConstructor
 public class ChatRestController {
+    private final ChatService chatService;
+
+    @PostMapping("")
+    public ResponseEntity<ApiResponse> saveChat(
+            @RequestBody ChatRequestDto.ChatLogDto request)
+    {
+        ChatResponseDto.ChatResultDto response = chatService.saveChatLog(request);
+        return ApiResponse.onSuccess(SuccessStatus._OK, response);
+    }
 }

--- a/DriveMate/spring/src/main/java/DriveMate/spring/domain/chat/dto/ChatRequestDto.java
+++ b/DriveMate/spring/src/main/java/DriveMate/spring/domain/chat/dto/ChatRequestDto.java
@@ -1,4 +1,36 @@
 package DriveMate.spring.domain.chat.dto;
 
+import DriveMate.spring.domain.chat.entity.Role;
+import DriveMate.spring.domain.member.entity.MemberSex;
+import DriveMate.spring.domain.member.entity.Mode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
 public class ChatRequestDto {
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ChatMessageDto {
+        private Role role;
+        private String chat;
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ChatLogDto {
+        private Long memberId;
+        private LocalDateTime date;
+        private String summary;
+        private String keywords;
+        private List<ChatMessageDto> chatting;
+    }
 }

--- a/DriveMate/spring/src/main/java/DriveMate/spring/domain/chat/dto/ChatRequestDto.java
+++ b/DriveMate/spring/src/main/java/DriveMate/spring/domain/chat/dto/ChatRequestDto.java
@@ -1,0 +1,4 @@
+package DriveMate.spring.domain.chat.dto;
+
+public class ChatRequestDto {
+}

--- a/DriveMate/spring/src/main/java/DriveMate/spring/domain/chat/dto/ChatResponseDto.java
+++ b/DriveMate/spring/src/main/java/DriveMate/spring/domain/chat/dto/ChatResponseDto.java
@@ -1,0 +1,4 @@
+package DriveMate.spring.domain.chat.dto;
+
+public class ChatResponseDto {
+}

--- a/DriveMate/spring/src/main/java/DriveMate/spring/domain/chat/dto/ChatResponseDto.java
+++ b/DriveMate/spring/src/main/java/DriveMate/spring/domain/chat/dto/ChatResponseDto.java
@@ -1,4 +1,20 @@
 package DriveMate.spring.domain.chat.dto;
 
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
 public class ChatResponseDto {
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ChatResultDto {
+        private Long memberId;
+        private LocalDateTime date;
+        private String summary;
+        private String keywords;
+        private List<ChatRequestDto.ChatMessageDto> chatting;
+    }
 }

--- a/DriveMate/spring/src/main/java/DriveMate/spring/domain/chat/entity/ChatLog.java
+++ b/DriveMate/spring/src/main/java/DriveMate/spring/domain/chat/entity/ChatLog.java
@@ -22,7 +22,7 @@ public class ChatLog {
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 
-    private LocalDateTime Date;
+    private LocalDateTime date;
 
     private String summary;
 

--- a/DriveMate/spring/src/main/java/DriveMate/spring/domain/chat/entity/ChatLog.java
+++ b/DriveMate/spring/src/main/java/DriveMate/spring/domain/chat/entity/ChatLog.java
@@ -5,6 +5,7 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Entity
 @Getter
@@ -12,25 +13,21 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-@Table(name = "chat")
-public class Chat {
+public class ChatLog {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long sessionId;
+    private Long ChatLogId;
 
     @ManyToOne
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 
-    private LocalDateTime startedAt;
+    private LocalDateTime Date;
 
-    private LocalDateTime endedAt;
+    private String summary;
 
-    @Lob
-    private String content;
+    private String keywords;
 
-    private boolean isDeleted;
-
-    private LocalDateTime deletedAt;
-
+    @OneToMany(mappedBy = "chatLog", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ChatMessage> chatting;
 }

--- a/DriveMate/spring/src/main/java/DriveMate/spring/domain/chat/entity/ChatMessage.java
+++ b/DriveMate/spring/src/main/java/DriveMate/spring/domain/chat/entity/ChatMessage.java
@@ -1,0 +1,26 @@
+package DriveMate.spring.domain.chat.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ChatMessage {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long ChatMessageId;
+
+    @Enumerated(EnumType.STRING)
+    private Role role;
+
+    private String chat;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "ChatLog_id")
+    private ChatLog chatLog;
+}

--- a/DriveMate/spring/src/main/java/DriveMate/spring/domain/chat/entity/Role.java
+++ b/DriveMate/spring/src/main/java/DriveMate/spring/domain/chat/entity/Role.java
@@ -1,0 +1,5 @@
+package DriveMate.spring.domain.chat.entity;
+
+public enum Role {
+    gpt, user;
+}

--- a/DriveMate/spring/src/main/java/DriveMate/spring/domain/chat/repository/ChatLogRepository.java
+++ b/DriveMate/spring/src/main/java/DriveMate/spring/domain/chat/repository/ChatLogRepository.java
@@ -1,7 +1,9 @@
 package DriveMate.spring.domain.chat.repository;
 
+import DriveMate.spring.domain.chat.entity.ChatLog;
+import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface ChatLogRepository {
+public interface ChatLogRepository extends JpaRepository<ChatLog, Long> {
 }

--- a/DriveMate/spring/src/main/java/DriveMate/spring/domain/chat/repository/ChatLogRepository.java
+++ b/DriveMate/spring/src/main/java/DriveMate/spring/domain/chat/repository/ChatLogRepository.java
@@ -1,0 +1,7 @@
+package DriveMate.spring.domain.chat.repository;
+
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ChatLogRepository {
+}

--- a/DriveMate/spring/src/main/java/DriveMate/spring/domain/chat/repository/ChatMessageRepository.java
+++ b/DriveMate/spring/src/main/java/DriveMate/spring/domain/chat/repository/ChatMessageRepository.java
@@ -1,0 +1,7 @@
+package DriveMate.spring.domain.chat.repository;
+
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ChatMessageRepository {
+}

--- a/DriveMate/spring/src/main/java/DriveMate/spring/domain/chat/repository/ChatMessageRepository.java
+++ b/DriveMate/spring/src/main/java/DriveMate/spring/domain/chat/repository/ChatMessageRepository.java
@@ -1,7 +1,9 @@
 package DriveMate.spring.domain.chat.repository;
 
+import DriveMate.spring.domain.chat.entity.ChatMessage;
+import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface ChatMessageRepository {
+public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
 }

--- a/DriveMate/spring/src/main/java/DriveMate/spring/domain/chat/service/ChatService.java
+++ b/DriveMate/spring/src/main/java/DriveMate/spring/domain/chat/service/ChatService.java
@@ -1,0 +1,4 @@
+package DriveMate.spring.domain.chat.service;
+
+public interface ChatService {
+}

--- a/DriveMate/spring/src/main/java/DriveMate/spring/domain/chat/service/ChatService.java
+++ b/DriveMate/spring/src/main/java/DriveMate/spring/domain/chat/service/ChatService.java
@@ -1,4 +1,8 @@
 package DriveMate.spring.domain.chat.service;
 
+import DriveMate.spring.domain.chat.dto.ChatRequestDto;
+import DriveMate.spring.domain.chat.dto.ChatResponseDto;
+
 public interface ChatService {
+    ChatResponseDto.ChatResultDto saveChatLog(ChatRequestDto.ChatLogDto request);
 }

--- a/DriveMate/spring/src/main/java/DriveMate/spring/domain/chat/service/ChatServiceImpl.java
+++ b/DriveMate/spring/src/main/java/DriveMate/spring/domain/chat/service/ChatServiceImpl.java
@@ -1,9 +1,62 @@
 package DriveMate.spring.domain.chat.service;
 
+import DriveMate.spring.common.exception.GeneralException;
+import DriveMate.spring.common.status.ErrorStatus;
+import DriveMate.spring.domain.chat.dto.ChatRequestDto;
+import DriveMate.spring.domain.chat.dto.ChatResponseDto;
+import DriveMate.spring.domain.chat.entity.ChatLog;
+import DriveMate.spring.domain.chat.entity.ChatMessage;
+import DriveMate.spring.domain.chat.repository.ChatLogRepository;
+import DriveMate.spring.domain.chat.repository.ChatMessageRepository;
+import DriveMate.spring.domain.member.entity.Member;
+import DriveMate.spring.domain.member.repository.MemberRepository;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Service
 @RequiredArgsConstructor
-public class ChatServiceImpl {
+public class ChatServiceImpl implements ChatService {
+    private final MemberRepository memberRepository;
+    private final ChatLogRepository chatLogRepository;
+    private final ChatMessageRepository chatMessageRepository;
+
+    @Override
+    @Transactional
+    public ChatResponseDto.ChatResultDto saveChatLog(ChatRequestDto.ChatLogDto request) {
+        Member member = memberRepository.findById(request.getMemberId())
+                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
+
+        ChatLog chatLog = ChatLog.builder()
+                .member(member)
+                .date(request.getDate())
+                .summary(request.getSummary())
+                .keywords(request.getKeywords())
+                .build();
+        ChatLog savedChatLog = chatLogRepository.save(chatLog);
+
+        List<ChatMessage> messages = request.getChatting().stream()
+                .map(chatMessageDto -> ChatMessage.builder()
+                        .role(chatMessageDto.getRole())
+                        .chat(chatMessageDto.getChat())
+                        .chatLog(savedChatLog)
+                        .build())
+                .collect(Collectors.toList());
+        chatMessageRepository.saveAll(messages);
+
+        List<ChatRequestDto.ChatMessageDto> chatMessageDtos = messages.stream()
+                .map(msg -> new ChatRequestDto.ChatMessageDto(msg.getRole(), msg.getChat()))
+                .collect(Collectors.toList());
+
+        return ChatResponseDto.ChatResultDto.builder()
+                .memberId(member.getMemberId())
+                .date(chatLog.getDate())
+                .summary(chatLog.getSummary())
+                .keywords(chatLog.getKeywords())
+                .chatting(chatMessageDtos)
+                .build();
+    }
 }

--- a/DriveMate/spring/src/main/java/DriveMate/spring/domain/chat/service/ChatServiceImpl.java
+++ b/DriveMate/spring/src/main/java/DriveMate/spring/domain/chat/service/ChatServiceImpl.java
@@ -1,0 +1,9 @@
+package DriveMate.spring.domain.chat.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ChatServiceImpl {
+}

--- a/DriveMate/spring/src/main/java/DriveMate/spring/domain/member/entity/Member.java
+++ b/DriveMate/spring/src/main/java/DriveMate/spring/domain/member/entity/Member.java
@@ -1,6 +1,6 @@
 package DriveMate.spring.domain.member.entity;
 
-import DriveMate.spring.domain.chat.entity.Chat;
+import DriveMate.spring.domain.chat.entity.ChatLog;
 import DriveMate.spring.domain.memberKeyword.entity.MemberKeyword;
 import jakarta.persistence.*;
 import lombok.*;
@@ -69,6 +69,6 @@ public class Member {
     private List<MemberKeyword> memberKeywords;
 
     @OneToMany(mappedBy = "member")
-    private List<Chat> chats;
+    private List<ChatLog> chats;
 
 }


### PR DESCRIPTION
## 📝 작업 내용

- 초기에 설계했던 chat 엔티티를 chatLog 엔티티와 chatMessage 엔티티로 분리함.
- GPT에서 넘어온 대화 내용 및 로그를 저장하는 API 구현함.

### 📸 스크린샷 (선택)
<img width="491" alt="image" src="https://github.com/user-attachments/assets/c6048b05-0ad7-4bf6-b8b3-c0a35b8427bf" />
