### PR TITLE
✨ [FEAT] #20: 메인 서버단 AI 연결 및 대화 관련 저장 API 통합

### DIFF
--- a/drivemate/src/main/java/x10/drivemate/common/status/ErrorStatus.java
+++ b/drivemate/src/main/java/x10/drivemate/common/status/ErrorStatus.java
@@ -25,6 +25,7 @@ public enum ErrorStatus {
 
     CHAT_NOT_FOUND(HttpStatus.BAD_REQUEST, "CHAT4001", "해당 ID의 대화내역이 없습니다."),
     CHAT_FORBIDDEN(HttpStatus.BAD_REQUEST, "CHAT4002", "해당 chat에 권한이 없습니다."),
+    CHATGPT_PARSING_ERROR(HttpStatus.BAD_REQUEST, "CHAT4003",  "AI 응답 파싱 과정에서 오류가 생겼습니다."),
 
     CATEGORY_NOT_FOUND(HttpStatus.BAD_REQUEST, "CATEGORY4001", "해당 카테고리가 없습니다."),
 

--- a/drivemate/src/main/java/x10/drivemate/common/status/ErrorStatus.java
+++ b/drivemate/src/main/java/x10/drivemate/common/status/ErrorStatus.java
@@ -26,6 +26,8 @@ public enum ErrorStatus {
     CHAT_NOT_FOUND(HttpStatus.BAD_REQUEST, "CHAT4001", "해당 ID의 대화내역이 없습니다."),
     CHAT_FORBIDDEN(HttpStatus.BAD_REQUEST, "CHAT4002", "해당 chat에 권한이 없습니다."),
     CHATGPT_PARSING_ERROR(HttpStatus.BAD_REQUEST, "CHAT4003",  "AI 응답 파싱 과정에서 오류가 생겼습니다."),
+    AI_BODY_ERROR(HttpStatus.BAD_REQUEST, "CHAT4004", "AI 요청 본문 직렬화 실패"),
+    EXTERNAL_API_ERROR(HttpStatus.BAD_REQUEST, "CHAT4005", "OpenAI API 응답 구조 오류"),
 
     CATEGORY_NOT_FOUND(HttpStatus.BAD_REQUEST, "CATEGORY4001", "해당 카테고리가 없습니다."),
 

--- a/drivemate/src/main/java/x10/drivemate/domain/chat/controller/ChatRestController.java
+++ b/drivemate/src/main/java/x10/drivemate/domain/chat/controller/ChatRestController.java
@@ -24,12 +24,14 @@ public class ChatRestController {
 
     @PostMapping("")
     public ResponseEntity<ApiResponse> saveChat(
-            @RequestBody ChatRequestDto.ChatLogDto request)
+            @RequestBody ChatRequestDto.ChatLogDto request,
+            @AuthenticationPrincipal CustomUserPrincipal userPrincipal)
     {
-        ChatResponseDto.ChatLogResultDto response = chatService.saveChatLog(request);
+        ChatResponseDto.ChatLogResultDto response = chatService.saveChatLog(request, userPrincipal);
         return ApiResponse.onSuccess(SuccessStatus._OK, response);
     }
 
+    /*
     @PostMapping("/summary")
     public ResponseEntity<ApiResponse> saveChatSummary(
             @RequestBody ChatRequestDto.ChatSummaryDto request)
@@ -37,6 +39,7 @@ public class ChatRestController {
         chatService.saveChatSummary(request);
         return ApiResponse.onSuccess(SuccessStatus._OK);
     }
+     */
 
     @GetMapping("/{chatId}")
     public ResponseEntity<ApiResponse> getChatinfo(

--- a/drivemate/src/main/java/x10/drivemate/domain/chat/dto/ChatResponseDto.java
+++ b/drivemate/src/main/java/x10/drivemate/domain/chat/dto/ChatResponseDto.java
@@ -24,6 +24,8 @@ public class ChatResponseDto {
     @AllArgsConstructor
     public static class ChatLogResultDto {
         private Long chatId;
+        private String summary;
+        private String keywords;
     }
 
     @Getter

--- a/drivemate/src/main/java/x10/drivemate/domain/chat/dto/GptResponseDto.java
+++ b/drivemate/src/main/java/x10/drivemate/domain/chat/dto/GptResponseDto.java
@@ -1,0 +1,20 @@
+package x10.drivemate.domain.chat.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class GptResponseDto {
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class GptSummaryKeywordDto {
+        private String summary;
+        private String keywords;
+    }
+}

--- a/drivemate/src/main/java/x10/drivemate/domain/chat/service/ChatGptService.java
+++ b/drivemate/src/main/java/x10/drivemate/domain/chat/service/ChatGptService.java
@@ -3,7 +3,7 @@ package x10.drivemate.domain.chat.service;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
-import lombok.Value;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.*;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
@@ -11,6 +11,11 @@ import x10.drivemate.common.exception.GeneralException;
 import x10.drivemate.common.status.ErrorStatus;
 import x10.drivemate.domain.chat.dto.ChatResponseDto;
 import x10.drivemate.domain.chat.dto.GptResponseDto;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
@@ -26,7 +31,7 @@ public class ChatGptService {
 
     public GptResponseDto.GptSummaryKeywordDto generateSummaryAndKeywords(String chatLog) {
         String prompt =
-                "Please summarize the following conversation in one sentence and extract key keywords. Provide the output in the following format:\n" +
+                "Please summarize the following conversation in one sentence and extract key keywords. Provide the summary and keywords **in Korean**. The summary must be only one sentence.\n" +
                 "\n" +
                 "Summary: {your summary}\n" +
                 "Keywords: {keyword1, keyword2, keyword3}\n" +
@@ -38,23 +43,51 @@ public class ChatGptService {
         headers.set("Authorization", "Bearer " + apiKey);
         headers.setContentType(MediaType.APPLICATION_JSON);
 
-        String body = "{"
-                + "\"model\": \"text-davinci-003\","
-                + "\"prompt\": \"" + prompt + "\","
-                + "\"max_tokens\": 150"
-                + "}";
+        Map<String, Object> requestBody = new HashMap<>();
+        requestBody.put("model", "gpt-4");
+        requestBody.put("max_tokens", 150);
 
-        HttpEntity<String> request = new HttpEntity<>(body, headers);
+        List<Map<String, String>> messages = new ArrayList<>();
+        messages.add(createMessage("system", "You are a helpful assistant that summarizes conversations and extracts keywords."));
+        messages.add(createMessage("user", prompt));
+
+        requestBody.put("messages", messages);
+
+
+        String jsonBody;
+        try {
+            jsonBody = objectMapper.writeValueAsString(requestBody);
+        } catch (Exception e) {
+            throw new GeneralException(ErrorStatus.AI_BODY_ERROR);
+        }
+
+        HttpEntity<String> request = new HttpEntity<>(jsonBody, headers);
 
         ResponseEntity<String> response = restTemplate.exchange(apiUrl, HttpMethod.POST, request, String.class);
 
         try {
             JsonNode responseJson = objectMapper.readTree(response.getBody());
-            String getResponse = responseJson.get("choices").get(0).get("test").asText().trim();
+            JsonNode firstChoice = responseJson.get("choices").get(0);
+            JsonNode messageNode = firstChoice.get("message");
 
-            String[] parts = getResponse.split("Keywords:");
+            if (messageNode == null) {
+                throw new GeneralException(ErrorStatus.EXTERNAL_API_ERROR);
+            }
+
+            JsonNode contentNode = messageNode.get("content");
+            if (contentNode == null) {
+                throw new GeneralException(ErrorStatus.EXTERNAL_API_ERROR);
+            }
+
+            String getResponse = contentNode.asText().trim();
+
+            String[] parts = getResponse.split("Keywords:", 2);
             String summary = parts[0].trim();
             String keywords = parts.length > 1 ? parts[1].trim() : "";
+
+            if (summary.startsWith("Summary:")) {
+                summary = summary.substring("Summary:".length()).trim();
+            }
 
             return GptResponseDto.GptSummaryKeywordDto.builder()
                     .summary(summary)
@@ -62,8 +95,15 @@ public class ChatGptService {
                     .build();
 
         } catch (Exception e) {
-            throw new GeneralException(ErrorStatus.CHAT_NOT_FOUND);
+            throw new GeneralException(ErrorStatus.CHATGPT_PARSING_ERROR);
         }
 
+    }
+
+    private Map<String, String> createMessage(String role, String content) {
+        Map<String, String> message = new HashMap<>();
+        message.put("role", role);
+        message.put("content", content);
+        return message;
     }
 }

--- a/drivemate/src/main/java/x10/drivemate/domain/chat/service/ChatGptService.java
+++ b/drivemate/src/main/java/x10/drivemate/domain/chat/service/ChatGptService.java
@@ -1,0 +1,69 @@
+package x10.drivemate.domain.chat.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import x10.drivemate.common.exception.GeneralException;
+import x10.drivemate.common.status.ErrorStatus;
+import x10.drivemate.domain.chat.dto.ChatResponseDto;
+import x10.drivemate.domain.chat.dto.GptResponseDto;
+
+@Service
+@RequiredArgsConstructor
+public class ChatGptService {
+    @Value("${openai.api.key}")
+    private String apiKey;
+
+    @Value("${openai.api.url}")
+    private String apiUrl;
+
+    private final RestTemplate restTemplate;
+    private final ObjectMapper objectMapper;
+
+    public GptResponseDto.GptSummaryKeywordDto generateSummaryAndKeywords(String chatLog) {
+        String prompt =
+                "Please summarize the following conversation in one sentence and extract key keywords. Provide the output in the following format:\n" +
+                "\n" +
+                "Summary: {your summary}\n" +
+                "Keywords: {keyword1, keyword2, keyword3}\n" +
+                "\n" +
+                "Conversation:\n" +
+                chatLog;
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", "Bearer " + apiKey);
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        String body = "{"
+                + "\"model\": \"text-davinci-003\","
+                + "\"prompt\": \"" + prompt + "\","
+                + "\"max_tokens\": 150"
+                + "}";
+
+        HttpEntity<String> request = new HttpEntity<>(body, headers);
+
+        ResponseEntity<String> response = restTemplate.exchange(apiUrl, HttpMethod.POST, request, String.class);
+
+        try {
+            JsonNode responseJson = objectMapper.readTree(response.getBody());
+            String getResponse = responseJson.get("choices").get(0).get("test").asText().trim();
+
+            String[] parts = getResponse.split("Keywords:");
+            String summary = parts[0].trim();
+            String keywords = parts.length > 1 ? parts[1].trim() : "";
+
+            return GptResponseDto.GptSummaryKeywordDto.builder()
+                    .summary(summary)
+                    .keywords(keywords)
+                    .build();
+
+        } catch (Exception e) {
+            throw new GeneralException(ErrorStatus.CHAT_NOT_FOUND);
+        }
+
+    }
+}

--- a/drivemate/src/main/java/x10/drivemate/domain/chat/service/ChatService.java
+++ b/drivemate/src/main/java/x10/drivemate/domain/chat/service/ChatService.java
@@ -10,7 +10,7 @@ import x10.drivemate.global.security.CustomUserPrincipal;
 import java.util.List;
 
 public interface ChatService {
-    ChatResponseDto.ChatLogResultDto saveChatLog(ChatRequestDto.ChatLogDto request);
+    ChatResponseDto.ChatLogResultDto saveChatLog(ChatRequestDto.ChatLogDto request, CustomUserPrincipal userPrincipal);
     void saveChatSummary(ChatRequestDto.ChatSummaryDto request);
     ChatResponseDto.ChatResultDto getChat(Long chatId, CustomUserPrincipal userPrincipal);
     void deleteChat(Long chatId, CustomUserPrincipal userPrincipal);

--- a/drivemate/src/main/java/x10/drivemate/domain/chat/service/ChatServiceImpl.java
+++ b/drivemate/src/main/java/x10/drivemate/domain/chat/service/ChatServiceImpl.java
@@ -33,8 +33,8 @@ public class ChatServiceImpl implements ChatService {
 
     @Override
     @Transactional
-    public ChatResponseDto.ChatLogResultDto saveChatLog(ChatRequestDto.ChatLogDto request) {
-        Member member = memberRepository.findById(request.getMemberId())
+    public ChatResponseDto.ChatLogResultDto saveChatLog(ChatRequestDto.ChatLogDto request, CustomUserPrincipal userPrincipal) {
+        Member member = memberRepository.findById(userPrincipal.getMemberId())
                 .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
 
         ChatLog chatLog = ChatLog.builder()

--- a/drivemate/src/main/java/x10/drivemate/domain/chat/service/ChatServiceImpl.java
+++ b/drivemate/src/main/java/x10/drivemate/domain/chat/service/ChatServiceImpl.java
@@ -1,6 +1,7 @@
 package x10.drivemate.domain.chat.service;
 
 import x10.drivemate.common.exception.GeneralException;
+import x10.drivemate.domain.chat.dto.GptResponseDto;
 import x10.drivemate.domain.member.entity.Member;
 import x10.drivemate.domain.member.repository.MemberRepository;
 import jakarta.transaction.Transactional;
@@ -30,6 +31,7 @@ public class ChatServiceImpl implements ChatService {
     private final MemberRepository memberRepository;
     private final ChatLogRepository chatLogRepository;
     private final ChatMessageRepository chatMessageRepository;
+    private final ChatGptService chatGptService;
 
     @Override
     @Transactional
@@ -53,12 +55,25 @@ public class ChatServiceImpl implements ChatService {
                 .collect(Collectors.toList());
         chatMessageRepository.saveAll(messages);
 
+        // gpt 호출하여 요약 및 키워드 추출
+        String conversation = messages.stream()
+                .map(ChatMessage::getChat)
+                .collect(Collectors.joining("\n"));  // 대화 내용 합치기
+
+        GptResponseDto.GptSummaryKeywordDto gptResponse = chatGptService.generateSummaryAndKeywords(conversation);
+
+        savedChatLog.setKeywords(gptResponse.getKeywords());
+        savedChatLog.setSummary(gptResponse.getSummary());
+        chatLogRepository.save(savedChatLog);
+
         List<ChatRequestDto.ChatMessageDto> chatMessageDtos = messages.stream()
                 .map(msg -> new ChatRequestDto.ChatMessageDto(msg.getRole(), msg.getChat(), msg.getIdx()))
                 .collect(Collectors.toList());
 
         return ChatResponseDto.ChatLogResultDto.builder()
                 .chatId(chatLog.getChatLogId())
+                .summary(gptResponse.getSummary())
+                .keywords(gptResponse.getKeywords())
                 .build();
     }
 

--- a/drivemate/src/main/java/x10/drivemate/domain/member/controller/MemberRestContoller.java
+++ b/drivemate/src/main/java/x10/drivemate/domain/member/controller/MemberRestContoller.java
@@ -6,6 +6,7 @@ import x10.drivemate.common.response.ApiResponse;
 import x10.drivemate.common.status.SuccessStatus;
 import x10.drivemate.domain.member.dto.MemberRequestDto;
 import x10.drivemate.domain.member.dto.MemberResponseDto;
+import x10.drivemate.domain.member.service.JwtTokenProvider;
 import x10.drivemate.domain.member.service.KakaoService;
 import x10.drivemate.domain.member.service.MemberService;
 import jakarta.validation.Valid;
@@ -23,6 +24,7 @@ public class MemberRestContoller {
 
     private final MemberService memberService;
     private final KakaoService kakaoService;
+    private final JwtTokenProvider jwtTokenProvider;
 
     /*
     // 기본 회원가입
@@ -66,5 +68,12 @@ public class MemberRestContoller {
     ) {
         MemberResponseDto.userInfodto response = memberService.getUserInfo(userPrincipal.getMemberId());
         return ApiResponse.onSuccess(SuccessStatus._OK, response);
+    }
+
+    // 테스트 토큰 발급
+    @GetMapping("/testToken")
+    public String generateAccessTokenForTest(@RequestParam String kakaoId) {
+        String accessToken = jwtTokenProvider.createToken(kakaoId);
+        return (accessToken);
     }
 }

--- a/drivemate/src/main/java/x10/drivemate/domain/member/service/JwtTokenProvider.java
+++ b/drivemate/src/main/java/x10/drivemate/domain/member/service/JwtTokenProvider.java
@@ -19,8 +19,8 @@ import javax.crypto.spec.SecretKeySpec;
 @Component
 @RequiredArgsConstructor
 public class JwtTokenProvider {
-    private final long ACCESS_TOKEN_VALIDITY = 1000L * 60 * 60; // 1시간
-    private final long REFRESH_TOKEN_VALIDITY = 1000L * 60 * 60 * 24 * 7; // 7일
+    private final long ACCESS_TOKEN_VALIDITY = 1000L * 60 * 60 * 24 * 7; // 7일
+    private final long REFRESH_TOKEN_VALIDITY = 1000L * 60 * 60 * 24 * 30; // 1달
 
     @Value("${jwt.secretKey}")
     private String secretKey;

--- a/drivemate/src/main/java/x10/drivemate/global/SecurityConfig.java
+++ b/drivemate/src/main/java/x10/drivemate/global/SecurityConfig.java
@@ -30,7 +30,7 @@ public class SecurityConfig {
         http
                 .csrf(csrf -> csrf.disable())// CSRF protection disabled for stateless applications
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/members/oauth/kakao", "/stretching","/api/member/login", "/api/member/signup").permitAll()
+                        .requestMatchers("/members/oauth/kakao", "/stretching","/api/member/login", "/api/member/signup", "members/testToken").permitAll()
                     .anyRequest().authenticated()) // Require authentication for all other requests
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);  // Add JWT filter before the default authentication filter
         return http.build();

--- a/drivemate/src/main/resources/application.properties
+++ b/drivemate/src/main/resources/application.properties
@@ -5,6 +5,10 @@ spring.datasource.url= ${RDS_URL}
 spring.datasource.username= ${RDS_USERNAME}
 spring.datasource.password= ${RDS_PASSWORD}
 
+# OpenAI API key
+openai.api.key= ${AI_KEY}
+openai.api.url= https://api.openai.com/v1/completions 
+
 # Hibernate Configuration
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true

--- a/drivemate/src/main/resources/application.properties
+++ b/drivemate/src/main/resources/application.properties
@@ -7,7 +7,7 @@ spring.datasource.password= ${RDS_PASSWORD}
 
 # OpenAI API key
 openai.api.key= ${AI_KEY}
-openai.api.url= https://api.openai.com/v1/completions 
+openai.api.url= https://api.openai.com/v1/chat/completions
 
 # Hibernate Configuration
 spring.jpa.hibernate.ddl-auto=update


### PR DESCRIPTION
## Issue
> close #20 


## 📝 작업 내용
- OpenAPI 연결 - 대화 한줄 요약, 키워드 추출
- 대화 내역 저장 API에 요약 + 키워드 저장 기능 합침
- 서버 단에서도 Test AccessToken(kakaoId) 발급할 수 있도록 코드 추가

